### PR TITLE
[doc] use HTTPS instead of HTTP to access the Nodejitsu API

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ Here is an example using the command line utility,
 [Curl](http://curl.haxx.se/):
 
      // get all applications for User "Marak"
-     curl --user Marak:password http://api.nodejitsu.com/apps/marak
+     curl --user Marak:password https://api.nodejitsu.com/apps/marak
 
 ## Applications
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -582,7 +582,7 @@ Here is an example using the command line utility,
 [Curl](http://curl.haxx.se/):
 
      // get all applications for User "Marak"
-     curl --user Marak:password http://api.nodejitsu.com/apps/marak
+     curl --user Marak:password https://api.nodejitsu.com/apps/marak
 
 ## Applications
 

--- a/appendices/mailchimp.md
+++ b/appendices/mailchimp.md
@@ -49,7 +49,7 @@ Like the rest of Nodejitsu's features, addon functionality can be accessed using
 Nodejitsu's JSON API. For example, here's what happens when you get 
 `/addons/:user-id`:
 
-    $ curl --user 'jesusabdullah:abc123' http://api.nodejitsu.com/addons/jesusabdullah/
+    $ curl --user 'jesusabdullah:abc123' https://api.nodejitsu.com/addons/jesusabdullah/
 
 
     { "_id": "jesusabdullah",
@@ -66,7 +66,7 @@ Nodejitsu's JSON API. For example, here's what happens when you get
 In order to interact with the MailChimp add-on in particular, use the
 `/addons/:user-id/signups` resource:
 
-    $ curl --user 'jesusabdullah:abc123' http://api.nodejitsu.com/addons/jesusabdullah/signups
+    $ curl --user 'jesusabdullah:abc123' https://api.nodejitsu.com/addons/jesusabdullah/signups
 
 
     { "lists": 
@@ -104,7 +104,7 @@ In order to interact with the MailChimp add-on in particular, use the
 You can use the list ID to access the particular list information with
 `/addons/:user-id/signups/:list-id/`:
 
-    curl --user 'jesusabdullah:abc123' http://api.nodejitsu.com/addons/jesusabdullah/signups/f3b7d6450c
+    curl --user 'jesusabdullah:abc123' https://api.nodejitsu.com/addons/jesusabdullah/signups/f3b7d6450c
 
 
     { "total": 2,

--- a/book.html
+++ b/book.html
@@ -18,11 +18,11 @@
       a {
         color: #000000;
       }
-      
+
       a:hover {
         color: blue;
       }
-      
+
     </style>
   </head>
   <body><div class='mp'>
@@ -125,7 +125,7 @@ var http = require('http');
 http.createServer(function (req, res) {
   // this is the callback, or request handler for the httpServer
 
-  // respond to the browser, write some headers so the 
+  // respond to the browser, write some headers so the
   // browser knows what type of content we are sending
   res.writeHead(200, {'Content-Type': 'text/html'});
 
@@ -192,8 +192,8 @@ prompted for some information such as <em><u>your app's name</u></em>, its
 only take a few seconds.</p>
 
 <pre><code>prompt: subdomain (myapp): myapp
-prompt: scripts.start (server.js): 
-prompt: version (0.0.0): 
+prompt: scripts.start (server.js):
+prompt: version (0.0.0):
 </code></pre>
 
 <p>Now just open up your favorite browser, and go to
@@ -529,21 +529,21 @@ any given resource or resource/action pair. for instance:</p>
 info:   Welcome to Nodejitsu
 info:   It worked if it ends with Nodejitsu ok
 info:   Executing command help apps deploy
-help:   
-help:   
+help:
+help:
 help:   Deploys an application using the following steps:
-help:   
+help:
 help:     1. Creates the application (if necessary)
 help:     2. Creates or validates the package.json
 help:     3. Packages and creates a new snapshot
 help:     4. Stops the application (if neccessary)
 help:     5. Starts the application
-help:   
+help:
 help:   jitsu deploy
 help:   jitsu apps deploy
-help:   
+help:
 info:   Nodejitsu ok
-josh@pidgey:~$ 
+josh@pidgey:~$
 </code></pre>
 
 <p>If no resource and/or action are specified, then <code>jitsu help</code> alone will
@@ -651,7 +651,7 @@ scenarios you should use our command line tool, <a data-bare-link="true" href="#
 <a href="http://curl.haxx.se/">Curl</a>:</p>
 
 <pre><code> // get all applications for User "Marak"
- curl --user Marak:password http://api.nodejitsu.com/apps/marak
+ curl --user Marak:password https://api.nodejitsu.com/apps/marak
 </code></pre>
 
 <h2 id="Applications">Applications</h2>
@@ -780,7 +780,7 @@ applications. Your logs are always saved and ready to be retrieved.</p>
   "from": "NOW-3YEARS",
   "until": "NOW",
   "rows": 15
-} 
+}
 </code></pre>
 
 <h3 id="Get-logs-for-a-specific-application">Get logs for a specific application</h3>
@@ -790,7 +790,7 @@ applications. Your logs are always saved and ready to be retrieved.</p>
   "from": "NOW-3YEARS",
   "until": "NOW",
   "rows": 15
-} 
+}
 </code></pre>
 
 <h2 id="Marketplace">Marketplace</h2>
@@ -842,12 +842,12 @@ haibu comes with a high-level Node.js API client.</p>
 
 <p>To start haibu, all you have to do is run <code>haibu</code>:</p>
 
-<pre><code>$ haibu 
-      __                  __               
-     / /_    ______  __  / /_     __  __   
-    / __ \  / __  / / / /  __ \  / / / /   
-   / / / / / /_/ / / / /  /_/ / / /_/ /    
-  /_/ /_/  \__,_/ /_/ /_/\___/  \__,_/     
+<pre><code>$ haibu
+      __                  __
+     / /_    ______  __  / /_     __  __
+    / __ \  / __  / / / /  __ \  / / / /
+   / / / / / /_/ / / / /  /_/ / / /_/ /
+  /_/ /_/  \__,_/ /_/ /_/\___/  \__,_/
 
   This is Open Source Software available under
   the MIT License.

--- a/book.md
+++ b/book.md
@@ -582,7 +582,7 @@ Here is an example using the command line utility,
 [Curl](http://curl.haxx.se/):
 
      // get all applications for User "Marak"
-     curl --user Marak:password http://api.nodejitsu.com/apps/marak
+     curl --user Marak:password https://api.nodejitsu.com/apps/marak
 
 ## Applications
 

--- a/chapters/json_api.md
+++ b/chapters/json_api.md
@@ -21,7 +21,7 @@ Here is an example using the command line utility,
 [Curl](http://curl.haxx.se/):
 
      // get all applications for User "Marak"
-     curl --user Marak:password http://api.nodejitsu.com/apps/marak
+     curl --user Marak:password https://api.nodejitsu.com/apps/marak
 
 ## Applications
 


### PR DESCRIPTION
The documentation was still using HTTP to access the Nodejitsu API while there is an HTTPS version available of the API.

I don't the right tools to re-generate the handbook, so that is something that needs to be done.
