### PR TITLE
Update hello-world.md to use port 80

### DIFF
--- a/content/articles/a-quickstart/hello-world.md
+++ b/content/articles/a-quickstart/hello-world.md
@@ -22,7 +22,7 @@ Let's start with a very basic Node.js http server. Create a folder called `myapp
     
     // close the response
     res.end();
-  }).listen(8080); // the server will listen on port 8080
+  }).listen(80); // the server will listen on port 80 - required for Nodejitsu
 ```
 
 That's all the code you'll need for starters. Save your server and get ready todeploy!


### PR DESCRIPTION
The current example server listens on port 8080, which results in a deployment error, because Nodejitsu requires you to listen for incoming connections on port 80 (as documented here: https://handbook.jitsu.com/a-quickstart/faq).

I've copied the deployment error here: https://gist.github.com/4341921

Looks like the process terminates prematurely - likely due to enforcement of the port 80 policy.

This proposed change updates the server to listen on port 80, and documents the requirement in the associated comment.
