### PR TITLE
Hook Io 's link doesn't work

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -13,7 +13,7 @@ Note that this entire website is generated from the individual content files in 
 
 We are a collection of seasoned developers who have been devoted to the Node.js community since 2009. We are community leaders who have created and contributed to hundreds of open-source Node.js projects. If you have used Node.js, you've probably used some of the projects we've helped create. 
 
-You can find our open source projects at <https://github.com/nodejitsu>, <https://github.com/flatiron>, and <https://github.com/nodeapps>.
+You can find our open source projects at <https://github.com/nodejitsu>, <https://github.com/flatiron> and <https://github.com/nodeapps>.
 
 <hr>
 ## What Is Nodejitsu?


### PR DESCRIPTION
In http://handbook.jitsu.com/, in 
¶ Who Is Nodejitsu? section,
The link https://github.com/hookio is empty..
